### PR TITLE
Allow per-conversion options, to allow multiple simultaneous convert calls with different options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var pdf2img = require('pdf2img');
 
 var input   = __dirname + '/test.pdf';
 
-pdf2img.setOptions({
+pdf2img.setGlobalBaseOptions({
   type: 'png',                                // png or jpg, default jpg
   size: 1024,                                 // default 1024
   density: 600,                               // default 600
@@ -31,6 +31,12 @@ pdf2img.setOptions({
 });
 
 pdf2img.convert(input, function(err, info) {
+  if (err) console.log(err)
+  else console.log(info);
+});
+
+// To provide options specific to a single conversion:
+pdf2img.convert(input, {page: 1}, function(err, info) {
   if (err) console.log(err)
   else console.log(info);
 });

--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -5,7 +5,7 @@ var gm = require('gm');
 var path = require('path');
 var async = require('async');
 
-var options = {
+var BASE_OPTIONS = {
   type: 'jpg',
   size: 1024,
   density: 600,
@@ -16,19 +16,37 @@ var options = {
 
 var Pdf2Img = function() {};
 
-Pdf2Img.prototype.setOptions = function(opts) {
-  options.type = opts.type || options.type;
-  options.size = opts.size || options.size;
-  options.density = opts.density || options.density;
-  options.outputdir = opts.outputdir || options.outputdir;
-  options.outputname = opts.outputname || options.outputname;
+var getOptions = function(opts) {
+  var options = Object.create(null);
+  options.type = opts.type || BASE_OPTIONS.type;
+  options.size = opts.size || BASE_OPTIONS.size;
+  options.density = opts.density || BASE_OPTIONS.density;
+  options.outputdir = opts.outputdir || BASE_OPTIONS.outputdir;
+  options.outputname = opts.outputname || BASE_OPTIONS.outputname;
   // Allows resetting to null.
-  if (opts.page !== undefined) {
+  options.page = BASE_OPTIONS.page;
+  if (opts.hasOwnProperty('page')) {
     options.page = opts.page;
   }
+  return options;
 };
 
-Pdf2Img.prototype.convert = function(input, callbackreturn) {
+// @deprecated Prefer #setGlobalBaseOptions(opts), as it does the same thing,
+//     but with a name that fully reflects what it does.
+Pdf2Img.prototype.setOptions = function(opts) {
+  this.setGlobalBaseOptions(opts);
+}
+
+Pdf2Img.prototype.setGlobalBaseOptions = function(opts) {
+  BASE_OPTIONS = getOptions(opts);
+}
+
+Pdf2Img.prototype.convert = function(input, opts, callbackreturn) {
+  if (arguments.length === 2) {
+    callbackreturn = opts;
+    opts = {};
+  }
+  var options = getOptions(opts);
   // Make sure it has correct extension
   if (path.extname(path.basename(input)) != '.pdf') {
     return callbackreturn({
@@ -106,7 +124,7 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
         var inputStream = fs.createReadStream(input);
         var outputFile = options.outputdir + options.outputname + '_' + page + '.' + options.type;
 
-        convertPdf2Img(inputStream, outputFile, parseInt(page), function(error, result) {
+        convertPdf2Img(inputStream, outputFile, parseInt(page), options, function(error, result) {
           if (error) {
             return callbackmap(error);
           }
@@ -126,7 +144,7 @@ Pdf2Img.prototype.convert = function(input, callbackreturn) {
   ], callbackreturn);
 };
 
-var convertPdf2Img = function(input, output, page, callback) {
+var convertPdf2Img = function(input, output, page, options, callback) {
   if (input.path) {
     var filepath = input.path;
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ var pdf2img = require('../index.js');
 var input   = __dirname + path.sep + 'test.pdf';
 var onePageInput = __dirname + path.sep + 'one_page.pdf';
 
-pdf2img.setOptions({
+pdf2img.setGlobalBaseOptions({
   outputdir: __dirname + path.sep + '/output',
   outputname: 'test'
 });
@@ -35,8 +35,8 @@ describe('Split and convert pdf into images', function() {
   });
   it ('Create png files', function(done) {
     this.timeout(100000);
-    pdf2img.setOptions({ type: 'png' });
-    pdf2img.convert(input, function(err, info) {
+    var opts = { type: 'png' };
+    pdf2img.convert(input, opts, function(err, info) {
       if (info.result !== 'success') {
         info.result.should.equal('success');
         done();
@@ -54,24 +54,23 @@ describe('Split and convert pdf into images', function() {
   });
   it ('Create jpg file only for given page', function(done) {
     this.timeout(100000);
-    pdf2img.setOptions({ type: 'jpg', page: 1 });
-    convertFileAndAssertExists(input, 1, 'jpg', done);
+    var opts = { type: 'jpg', page: 1 };
+    convertFileAndAssertExists(input, opts, 1, 'jpg', done);
   });
   it ('Create png file only for given page', function(done) {
     this.timeout(100000);
-    pdf2img.setOptions({ type: 'png', page: 2 });
-    convertFileAndAssertExists(input, 2, 'png', done);
+    var opts = { type: 'png', page: 2 };
+    convertFileAndAssertExists(input, opts, 2, 'png', done);
   });
   it ('Create jpg file for one page pdf', function(done) {
     this.timeout(100000);
-    // pdf2img options do not reset between tests.
-    pdf2img.setOptions({ type: 'jpg', page: null});
-    convertFileAndAssertExists(onePageInput, 1, 'jpg', done);
+    var opts = { type: 'jpg', page: null};
+    convertFileAndAssertExists(onePageInput, opts, 1, 'jpg', done);
   });
   it ('Create jpg file for one page pdf when specifying', function(done) {
     this.timeout(100000);
-    pdf2img.setOptions({ type: 'jpg', page: 1 });
-    convertFileAndAssertExists(onePageInput, 1, 'jpg', done);
+    var opts = { type: 'jpg', page: 1 };
+    convertFileAndAssertExists(onePageInput, opts, 1, 'jpg', done);
   });
 });
 


### PR DESCRIPTION
Currently, calling `pdf2img#setOptions` will overwrite the module-level options, which are effectively global due to module caching. That means `pdf2img#convert` can't safely be called from more than one place in parallel with different options.

This PR allows passing in per-conversion options, in a backwards-compatible way:

* Renames `pdf2img#setOptions` to `pdf2img#setGlobalBaseOptions` to reflect its behavior. I keep the old one around, marked as deprecated, so that this change is backwards-compatible.
* Allow an optional second `opts` parameter to `pdf2img#convert`, for per-conversion options.

I considered an alternative approach of setting options onto the instance. However, this module creates and exports a singleton instance, so setting options as an instance property wouldn't have actually allowed per-conversion options. Making the module export the class would have been a very backwards-incompatible change.