### PR TITLE
Fix double callback

### DIFF
--- a/lib/pdf2img.js
+++ b/lib/pdf2img.js
@@ -133,7 +133,9 @@ Pdf2Img.prototype.convert = function(input, opts, callbackreturn) {
           return callbackmap(error, result);
         });
       }, function(e) {
-        if (e) callback(e);
+        if (e) {
+          return callback(e);
+        }
 
         return callback(null, {
           result: 'success',


### PR DESCRIPTION
If `#convert` fails, the callback gets called twice, since the error branch doesn't return. This PR fixes that.

I did a scan over the rest of the code and didn't see any other double-callbacks.